### PR TITLE
refactor: rename serve command to "start mcp server" and replace Click to Typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,10 @@ Detailed usage examples will be provided in the videos—please stay tuned!
 ### Installation
 
 ```bash
-# Via uv (recommended)
-uv pip install wassden
+# Direct install from GitHub (recommended)
+uvx --from git+https://github.com/tokusumi/wassden-mcp wassden
 
-# Via pip
-pip install wassden
-
-# Via git
+# Or development installation
 git clone https://github.com/tokusumi/wassden-mcp
 cd wassden-py
 uv pip install -e .
@@ -52,24 +49,47 @@ uv pip install -e .
 
 ### MCP Integration
 
+#### Transport Options
+
+wassden supports multiple transport protocols for maximum compatibility:
+
+- **stdio** (default): Standard input/output for Claude Code
+- **sse**: Server-Sent Events for HTTP-based communication
+- **streamable-http**: Streamable HTTP for web-based clients
+
 #### Claude Code Setup (Recommended)
 
-1. **Install the package**
+1. **Install uv (if not already installed)**
 
    ```bash
-   uv pip install wassden
+   # On macOS and Linux
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   
+   # On Windows
+   powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+   
+   # Via pip
+   pip install uv
    ```
 
 2. **Add to Claude Code settings**
 
    Edit `~/.claude/settings.json`:
 
+   **Using stdio transport (recommended for Claude Code)**
    ```json
    {
      "mcpServers": {
        "wassden": {
-         "command": "wassden",
-         "args": ["serve", "--server"],
+         "command": "uvx",
+         "args": [
+           "--from",
+           "git+https://github.com/tokusumi/wassden-mcp",
+           "wassden",
+           "start-mcp-server",
+           "--transport",
+           "stdio"
+         ],
          "env": {}
        }
      }
@@ -83,11 +103,20 @@ uv pip install -e .
 4. **Verify connection**
    ```bash
    # Manual verification
-   wassden check_completeness --userInput "test project"
+   uvx --from git+https://github.com/tokusumi/wassden-mcp wassden check_completeness --userInput "test project"
    ```
 
-#### Alternative: Development Installation
+#### IDE Compatibility
 
+wassden provides flexible transport options for MCP-compatible environments:
+
+- **Claude Code**: Full support via stdio transport (recommended)
+
+The transport flexibility ensures wassden can be integrated into any MCP-compatible development environment.
+
+#### Alternative Installation Methods
+
+**1. Development Installation**
 ```bash
 git clone https://github.com/tokusumi/wassden-mcp
 cd wassden-py
@@ -95,7 +124,6 @@ uv pip install -e .
 ```
 
 Then use absolute path in settings:
-
 ```json
 {
   "mcpServers": {
@@ -108,12 +136,18 @@ Then use absolute path in settings:
 }
 ```
 
+**2. Claude Code CLI**
+For quick setup with Claude Code CLI:
+```bash
+claude mcp add wassden "uvx --from git+https://github.com/tokusumi/wassden-mcp wassden start-mcp-server --transport stdio"
+```
+
 ### Basic Usage
 
 1. **Complete Project Analysis & Requirements Generation**
 
    ```bash
-   wassden check_completeness --userInput "Your project description"
+   uvx --from git+https://github.com/tokusumi/wassden-mcp wassden check_completeness --userInput "Your project description"
    ```
    
    This command analyzes your input for completeness and:
@@ -131,9 +165,9 @@ Then use absolute path in settings:
    
    wassden validates the agent-generated documents:
    ```bash
-   wassden validate_requirements specs/requirements.md
-   wassden validate_design specs/design.md
-   wassden validate_tasks specs/tasks.md
+   uvx --from git+https://github.com/tokusumi/wassden-mcp wassden validate_requirements specs/requirements.md
+   uvx --from git+https://github.com/tokusumi/wassden-mcp wassden validate_design specs/design.md
+   uvx --from git+https://github.com/tokusumi/wassden-mcp wassden validate_tasks specs/tasks.md
    ```
 
 ## 🛠️ Available Tools
@@ -297,9 +331,10 @@ uv pip install -e ".[dev]"
 make check                # Run format, lint, typecheck, and test with coverage
 make ci                   # CI checks without modifying files
 
-# Run MCP server
-wassden serve --server    # Start MCP server
-python -m wassden.server  # Alternative method
+# Run MCP server with different transports
+uvx --from git+https://github.com/tokusumi/wassden-mcp wassden start-mcp-server --transport stdio                                       # Start with stdio (default)
+uvx --from git+https://github.com/tokusumi/wassden-mcp wassden start-mcp-server --transport sse --host 127.0.0.1 --port 3001           # Start with SSE
+uvx --from git+https://github.com/tokusumi/wassden-mcp wassden start-mcp-server --transport streamable-http --host 0.0.0.0 --port 3001 # Start with streamable-http
 ```
 
 ### Continuous Integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.11.3",
-    "click>=8.2.1",
+    "typer>=0.12.5",
     "colorama>=0.4.6",
     "prompt-toolkit>=3.0.51",
     "typing-extensions>=4.14.1",
@@ -33,7 +33,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/tokusumi/wassden-mcp/issues"
 
 [project.scripts]
-wassden = "wassden.cli:main"
+wassden = "wassden.cli:app"
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -2,9 +2,9 @@
 
 from pathlib import Path
 
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
-from wassden.cli import cli
+from wassden.cli import app
 
 
 class TestCLICommands:
@@ -14,32 +14,32 @@ class TestCLICommands:
         """Set up test environment."""
         self.runner = CliRunner()
 
-    def test_cli_help(self):
+    def test_app_help(self):
         """Test CLI help command."""
-        result = self.runner.invoke(cli, ["--help"])
+        result = self.runner.invoke(app, ["--help"])
 
         assert result.exit_code == 0
         assert "wassden - MCP-based Spec-Driven Development toolkit" in result.output
         assert "check-completeness" in result.output
         assert "validate-requirements" in result.output
 
-    def test_cli_version(self):
+    def test_app_version(self):
         """Test CLI version command."""
-        result = self.runner.invoke(cli, ["--version"])
+        result = self.runner.invoke(app, ["--version"])
 
         assert result.exit_code == 0
         assert "0.1.0" in result.output
 
     def test_check_completeness_command(self):
         """Test check_completeness command."""
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", "Simple test project"])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", "Simple test project"])
 
         assert result.exit_code == 0
         assert "プロジェクト情報を確認" in result.output
 
     def test_check_completeness_missing_input(self):
         """Test check_completeness command without required input."""
-        result = self.runner.invoke(cli, ["check-completeness"])
+        result = self.runner.invoke(app, ["check-completeness"])
 
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
@@ -47,7 +47,7 @@ class TestCLICommands:
     def test_prompt_requirements_command(self):
         """Test prompt_requirements command."""
         result = self.runner.invoke(
-            cli, ["prompt-requirements", "--projectDescription", "Test project for CLI testing"]
+            app, ["prompt-requirements", "--projectDescription", "Test project for CLI testing"]
         )
 
         assert result.exit_code == 0
@@ -58,7 +58,7 @@ class TestCLICommands:
     def test_prompt_requirements_with_scope_and_constraints(self):
         """Test prompt_requirements with optional parameters."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "prompt-requirements",
                 "--projectDescription",
@@ -77,7 +77,7 @@ class TestCLICommands:
     def test_validate_requirements_file_not_found(self):
         """Test validate_requirements with non-existent file."""
         result = self.runner.invoke(
-            cli, ["validate-requirements", "--requirementsPath", "/nonexistent/requirements.md"]
+            app, ["validate-requirements", "--requirementsPath", "/nonexistent/requirements.md"]
         )
 
         assert result.exit_code == 0  # Command succeeds but shows error message
@@ -86,7 +86,7 @@ class TestCLICommands:
 
     def test_validate_requirements_default_path(self):
         """Test validate_requirements with default path."""
-        result = self.runner.invoke(cli, ["validate-requirements"])
+        result = self.runner.invoke(app, ["validate-requirements"])
 
         assert result.exit_code == 0
         # Should show validation success since specs/requirements.md exists
@@ -102,7 +102,7 @@ class TestCLICommands:
 - **REQ-01**: Test requirement
 """)
 
-            result = self.runner.invoke(cli, ["prompt-design"])
+            result = self.runner.invoke(app, ["prompt-design"])
 
             assert result.exit_code == 0
             assert "design.md" in result.output
@@ -136,7 +136,7 @@ Test NFR
 Test strategy
 """)
 
-            result = self.runner.invoke(cli, ["validate-design"])
+            result = self.runner.invoke(app, ["validate-design"])
 
             assert result.exit_code == 0
             assert "検証" in result.output
@@ -148,7 +148,7 @@ Test strategy
             Path("specs/requirements.md").write_text("## 機能要件\n- **REQ-01**: Test")
             Path("specs/design.md").write_text("## コンポーネント設計\n- **component**: Test")
 
-            result = self.runner.invoke(cli, ["prompt-tasks"])
+            result = self.runner.invoke(app, ["prompt-tasks"])
 
             assert result.exit_code == 0
             assert "tasks.md" in result.output
@@ -172,7 +172,7 @@ Dependencies
 Milestones
 """)
 
-            result = self.runner.invoke(cli, ["validate-tasks"])
+            result = self.runner.invoke(app, ["validate-tasks"])
 
             assert result.exit_code == 0
             assert "検証" in result.output
@@ -185,7 +185,7 @@ Milestones
             Path("specs/design.md").write_text("# Design\n- Component: Test")
             Path("specs/tasks.md").write_text("# Tasks\n- **TASK-01-01**: Test")
 
-            result = self.runner.invoke(cli, ["prompt-code"])
+            result = self.runner.invoke(app, ["prompt-code"])
 
             assert result.exit_code == 0
             assert "実装" in result.output
@@ -194,7 +194,7 @@ Milestones
     def test_analyze_changes_command(self):
         """Test analyze_changes command."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "analyze-changes",
                 "--changedFile",
@@ -216,7 +216,7 @@ Milestones
             Path("specs/design.md").write_text("## アーキテクチャ\n[REQ-01]")
             Path("specs/tasks.md").write_text("## タスク一覧\n- **TASK-01-01**: Test")
 
-            result = self.runner.invoke(cli, ["get-traceability"])
+            result = self.runner.invoke(app, ["get-traceability"])
 
             assert result.exit_code == 0
             assert "トレーサビリティレポート" in result.output
@@ -238,16 +238,17 @@ Milestones
         ]
 
         for cmd in commands:
-            result = self.runner.invoke(cli, [cmd, "--help"])
+            result = self.runner.invoke(app, [cmd, "--help"])
             assert result.exit_code == 0
             assert "Usage:" in result.output
-            assert "Options:" in result.output
+            # Typer uses rich formatting with box characters
+            assert "Options:" in result.output or "╭─" in result.output
 
     def test_command_error_handling(self):
         """Test command error handling."""
         # Test with invalid file path that will cause an error
         result = self.runner.invoke(
-            cli, ["validate-requirements", "--requirementsPath", "/invalid/path/that/definitely/does/not/exist.md"]
+            app, ["validate-requirements", "--requirementsPath", "/invalid/path/that/definitely/does/not/exist.md"]
         )
 
         # Command should handle the error gracefully
@@ -264,7 +265,7 @@ class TestCLIEdgeCases:
 
     def test_empty_user_input(self):
         """Test check_completeness with empty input."""
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", ""])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", ""])
 
         assert result.exit_code == 0
         # Should still provide guidance even with empty input
@@ -273,14 +274,14 @@ class TestCLIEdgeCases:
         """Test check_completeness with very long input."""
         long_input = "A" * 10000  # Very long input
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", long_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", long_input])
 
         assert result.exit_code == 0
 
     def test_japanese_input(self):
         """Test CLI with Japanese input."""
         result = self.runner.invoke(
-            cli,
+            app,
             ["check-completeness", "--userInput", "日本語のプロジェクト説明です。Python、FastAPI、Reactを使用します。"],
         )
 
@@ -290,7 +291,7 @@ class TestCLIEdgeCases:
     def test_special_characters_input(self):
         """Test CLI with special characters."""
         result = self.runner.invoke(
-            cli, ["check-completeness", "--userInput", "Project with symbols: !@#$%^&*()_+-={}[]|\\:;\"'<>?,./"]
+            app, ["check-completeness", "--userInput", "Project with symbols: !@#$%^&*()_+-={}[]|\\:;\"'<>?,./"]
         )
 
         assert result.exit_code == 0
@@ -298,7 +299,7 @@ class TestCLIEdgeCases:
     def test_multiple_flags_same_command(self):
         """Test command with multiple flags."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "prompt-requirements",
                 "--projectDescription",
@@ -328,7 +329,7 @@ class TestCLIIntegration:
         with self.runner.isolated_filesystem():
             # Step 1: Check completeness
             result1 = self.runner.invoke(
-                cli, ["check-completeness", "--userInput", "Python FastAPI web application for task management"]
+                app, ["check-completeness", "--userInput", "Python FastAPI web application for task management"]
             )
             assert result1.exit_code == 0
 
@@ -360,12 +361,12 @@ class TestCLIIntegration:
 """)
 
             # Step 3: Validate requirements
-            result3 = self.runner.invoke(cli, ["validate-requirements"])
+            result3 = self.runner.invoke(app, ["validate-requirements"])
             assert result3.exit_code == 0
             assert "検証に成功" in result3.output or "検証" in result3.output
 
             # Step 4: Generate design prompt
-            result4 = self.runner.invoke(cli, ["prompt-design"])
+            result4 = self.runner.invoke(app, ["prompt-design"])
             assert result4.exit_code == 0
             assert "design.md" in result4.output
 
@@ -391,11 +392,11 @@ Unit and integration tests
 """)
 
             # Step 5: Validate design
-            result5 = self.runner.invoke(cli, ["validate-design"])
+            result5 = self.runner.invoke(app, ["validate-design"])
             assert result5.exit_code == 0
 
             # Step 6: Generate tasks prompt
-            result6 = self.runner.invoke(cli, ["prompt-tasks"])
+            result6 = self.runner.invoke(app, ["prompt-tasks"])
             assert result6.exit_code == 0
             assert "tasks.md" in result6.output
 
@@ -417,15 +418,15 @@ TASK-01-01 → TASK-01-02 → TASK-02-01
 """)
 
             # Step 7: Validate tasks
-            result7 = self.runner.invoke(cli, ["validate-tasks"])
+            result7 = self.runner.invoke(app, ["validate-tasks"])
             assert result7.exit_code == 0
 
             # Step 8: Get traceability report
-            result8 = self.runner.invoke(cli, ["get-traceability"])
+            result8 = self.runner.invoke(app, ["get-traceability"])
             assert result8.exit_code == 0
             assert "トレーサビリティレポート" in result8.output
 
             # Step 9: Generate implementation prompt
-            result9 = self.runner.invoke(cli, ["prompt-code"])
+            result9 = self.runner.invoke(app, ["prompt-code"])
             assert result9.exit_code == 0
             assert "実装" in result9.output

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -221,13 +221,6 @@ Milestones
             assert result.exit_code == 0
             assert "トレーサビリティレポート" in result.output
 
-    def test_serve_command_without_server_flag(self):
-        """Test serve command without --server flag."""
-        result = self.runner.invoke(cli, ["serve"])
-
-        assert result.exit_code == 1
-        assert "Use --server flag" in result.output
-
     def test_all_commands_have_help(self):
         """Test that all commands have help text."""
         commands = [
@@ -241,7 +234,7 @@ Milestones
             "prompt-code",
             "analyze-changes",
             "get-traceability",
-            "serve",
+            "start-mcp-server",
         ]
 
         for cmd in commands:

--- a/tests/cli/test_cli_detailed.py
+++ b/tests/cli/test_cli_detailed.py
@@ -5,9 +5,9 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
-from wassden.cli import cli
+from wassden.cli import app
 
 # Constants for CLI exit codes
 CLI_USAGE_ERROR_CODE = 2
@@ -25,19 +25,21 @@ class TestCLIBasicFunctionality:
         """Clean up test environment after each test."""
         shutil.rmtree(self.temp_dir)
 
-    def test_cli_help_output_structure(self):
+    def test_app_help_output_structure(self):
         """Test CLI help output contains required structure."""
-        result = self.runner.invoke(cli, ["--help"])
+        result = self.runner.invoke(app, ["--help"])
 
         assert result.exit_code == 0
         assert "wassden - MCP-based Spec-Driven Development toolkit" in result.output
         assert "Usage:" in result.output
-        assert "Options:" in result.output
-        assert "Commands:" in result.output
+        # Typer uses rich formatting with box characters
+        assert "Options:" in result.output or "╭─" in result.output
+        # Typer uses rich formatting with box characters for commands section
+        assert "Commands:" in result.output or "╭─" in result.output
 
-    def test_cli_help_contains_all_commands(self):
+    def test_app_help_contains_all_commands(self):
         """Test CLI help contains all expected commands."""
-        result = self.runner.invoke(cli, ["--help"])
+        result = self.runner.invoke(app, ["--help"])
 
         expected_commands = [
             "check-completeness",
@@ -56,25 +58,25 @@ class TestCLIBasicFunctionality:
         for command in expected_commands:
             assert command in result.output
 
-    def test_cli_version_format(self):
+    def test_app_version_format(self):
         """Test CLI version output format."""
-        result = self.runner.invoke(cli, ["--version"])
+        result = self.runner.invoke(app, ["--version"])
 
         assert result.exit_code == 0
         # Version should be in format X.Y.Z
         version_pattern = r"\d+\.\d+\.\d+"
         assert re.search(version_pattern, result.output)
 
-    def test_cli_invalid_command(self):
+    def test_app_invalid_command(self):
         """Test CLI with invalid command."""
-        result = self.runner.invoke(cli, ["invalid-command"])
+        result = self.runner.invoke(app, ["invalid-command"])
 
         assert result.exit_code != 0
         assert "No such command" in result.output
 
-    def test_cli_no_arguments(self):
+    def test_app_no_arguments(self):
         """Test CLI with no arguments shows help."""
-        result = self.runner.invoke(cli, [])
+        result = self.runner.invoke(app, [])
 
         # CLI with no arguments shows usage error
         assert result.exit_code == CLI_USAGE_ERROR_CODE
@@ -90,7 +92,7 @@ class TestCheckCompletenessCommand:
 
     def test_check_completeness_help(self):
         """Test check-completeness help output."""
-        result = self.runner.invoke(cli, ["check-completeness", "--help"])
+        result = self.runner.invoke(app, ["check-completeness", "--help"])
 
         assert result.exit_code == 0
         assert "check-completeness" in result.output
@@ -99,14 +101,14 @@ class TestCheckCompletenessCommand:
 
     def test_check_completeness_missing_required_arg(self):
         """Test check-completeness without required userInput."""
-        result = self.runner.invoke(cli, ["check-completeness"])
+        result = self.runner.invoke(app, ["check-completeness"])
 
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
 
     def test_check_completeness_with_simple_input(self):
         """Test check-completeness with simple input."""
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", "Simple test project"])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", "Simple test project"])
 
         assert result.exit_code == 0
         assert "プロジェクト情報を確認" in result.output
@@ -121,14 +123,14 @@ class TestCheckCompletenessCommand:
         Scope: CRUD operations for tasks, user authentication, basic reporting
         """
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", complex_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", complex_input])
 
         assert result.exit_code == 0
         assert "プロジェクト情報を確認" in result.output
 
     def test_check_completeness_with_empty_input(self):
         """Test check-completeness with empty input."""
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", ""])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", ""])
 
         assert result.exit_code == 0
         # Should still provide some guidance even with empty input
@@ -137,7 +139,7 @@ class TestCheckCompletenessCommand:
         """Test check-completeness with special characters."""
         special_input = "Project with symbols: !@#$%^&*()_+-={}[]|\\:;\"'<>?,./"
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", special_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", special_input])
 
         assert result.exit_code == 0
 
@@ -145,7 +147,7 @@ class TestCheckCompletenessCommand:
         """Test check-completeness with Japanese input."""
         japanese_input = "日本語のプロジェクト説明です。Python、FastAPI、Reactを使用します。"
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", japanese_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", japanese_input])
 
         assert result.exit_code == 0
         assert "プロジェクト情報を確認" in result.output
@@ -154,7 +156,7 @@ class TestCheckCompletenessCommand:
         """Test check-completeness with very long input."""
         long_input = "A" * 10000  # 10KB of text
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", long_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", long_input])
 
         assert result.exit_code == 0
 
@@ -168,7 +170,7 @@ class TestPromptRequirementsCommand:
 
     def test_prompt_requirements_help(self):
         """Test prompt-requirements help output."""
-        result = self.runner.invoke(cli, ["prompt-requirements", "--help"])
+        result = self.runner.invoke(app, ["prompt-requirements", "--help"])
 
         assert result.exit_code == 0
         assert "prompt-requirements" in result.output
@@ -178,7 +180,7 @@ class TestPromptRequirementsCommand:
 
     def test_prompt_requirements_missing_required_arg(self):
         """Test prompt-requirements without required projectDescription."""
-        result = self.runner.invoke(cli, ["prompt-requirements"])
+        result = self.runner.invoke(app, ["prompt-requirements"])
 
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
@@ -186,7 +188,7 @@ class TestPromptRequirementsCommand:
     def test_prompt_requirements_basic_usage(self):
         """Test prompt-requirements with basic usage."""
         result = self.runner.invoke(
-            cli, ["prompt-requirements", "--projectDescription", "Test project for CLI testing"]
+            app, ["prompt-requirements", "--projectDescription", "Test project for CLI testing"]
         )
 
         assert result.exit_code == 0
@@ -197,7 +199,7 @@ class TestPromptRequirementsCommand:
     def test_prompt_requirements_with_scope(self):
         """Test prompt-requirements with scope parameter."""
         result = self.runner.invoke(
-            cli,
+            app,
             ["prompt-requirements", "--projectDescription", "Test project", "--scope", "Web application development"],
         )
 
@@ -207,7 +209,7 @@ class TestPromptRequirementsCommand:
     def test_prompt_requirements_with_constraints(self):
         """Test prompt-requirements with constraints parameter."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "prompt-requirements",
                 "--projectDescription",
@@ -223,7 +225,7 @@ class TestPromptRequirementsCommand:
     def test_prompt_requirements_with_all_parameters(self):
         """Test prompt-requirements with all parameters."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "prompt-requirements",
                 "--projectDescription",
@@ -242,7 +244,7 @@ class TestPromptRequirementsCommand:
 
     def test_prompt_requirements_empty_description(self):
         """Test prompt-requirements with empty description."""
-        result = self.runner.invoke(cli, ["prompt-requirements", "--projectDescription", ""])
+        result = self.runner.invoke(app, ["prompt-requirements", "--projectDescription", ""])
 
         assert result.exit_code == 0
         assert "requirements.md" in result.output
@@ -250,7 +252,7 @@ class TestPromptRequirementsCommand:
     def test_prompt_requirements_special_characters(self):
         """Test prompt-requirements with special characters."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "prompt-requirements",
                 "--projectDescription",
@@ -279,7 +281,7 @@ class TestValidateRequirementsCommand:
 
     def test_validate_requirements_help(self):
         """Test validate-requirements help output."""
-        result = self.runner.invoke(cli, ["validate-requirements", "--help"])
+        result = self.runner.invoke(app, ["validate-requirements", "--help"])
 
         assert result.exit_code == 0
         assert "validate-requirements" in result.output
@@ -287,7 +289,7 @@ class TestValidateRequirementsCommand:
 
     def test_validate_requirements_default_path(self):
         """Test validate-requirements with default path."""
-        result = self.runner.invoke(cli, ["validate-requirements"])
+        result = self.runner.invoke(app, ["validate-requirements"])
 
         assert result.exit_code == 0
         # Should show error message about missing file or attempt validation
@@ -296,7 +298,7 @@ class TestValidateRequirementsCommand:
     def test_validate_requirements_nonexistent_file(self):
         """Test validate-requirements with non-existent file."""
         result = self.runner.invoke(
-            cli, ["validate-requirements", "--requirementsPath", "/nonexistent/requirements.md"]
+            app, ["validate-requirements", "--requirementsPath", "/nonexistent/requirements.md"]
         )
 
         assert result.exit_code == 0  # Command succeeds but shows error message
@@ -334,7 +336,7 @@ class TestValidateRequirementsCommand:
 - **REQ-02**: システムは、出力を提供すること
 """)
 
-            result = self.runner.invoke(cli, ["validate-requirements"])
+            result = self.runner.invoke(app, ["validate-requirements"])
 
             assert result.exit_code == 0
             assert "検証" in result.output
@@ -354,7 +356,7 @@ Missing required sections and invalid IDs
 - **REQ-1**: Also invalid format
 """)
 
-            result = self.runner.invoke(cli, ["validate-requirements"])
+            result = self.runner.invoke(app, ["validate-requirements"])
 
             assert result.exit_code == 0
             # Should detect validation issues
@@ -369,7 +371,7 @@ Missing required sections and invalid IDs
 """)
 
             result = self.runner.invoke(
-                cli, ["validate-requirements", "--requirementsPath", "custom/my_requirements.md"]
+                app, ["validate-requirements", "--requirementsPath", "custom/my_requirements.md"]
             )
 
             assert result.exit_code == 0
@@ -380,7 +382,7 @@ Missing required sections and invalid IDs
             Path("specs").mkdir(exist_ok=True)
             Path("specs/requirements.md").write_text("")
 
-            result = self.runner.invoke(cli, ["validate-requirements"])
+            result = self.runner.invoke(app, ["validate-requirements"])
 
             assert result.exit_code == 0
             # Should handle empty file gracefully
@@ -395,7 +397,7 @@ class TestPromptDesignCommand:
 
     def test_prompt_design_help(self):
         """Test prompt-design help output."""
-        result = self.runner.invoke(cli, ["prompt-design", "--help"])
+        result = self.runner.invoke(app, ["prompt-design", "--help"])
 
         assert result.exit_code == 0
         assert "prompt-design" in result.output
@@ -403,7 +405,7 @@ class TestPromptDesignCommand:
 
     def test_prompt_design_default_path(self):
         """Test prompt-design with default path."""
-        result = self.runner.invoke(cli, ["prompt-design"])
+        result = self.runner.invoke(app, ["prompt-design"])
 
         assert result.exit_code == 0
         # Should show error about missing requirements file or attempt to generate prompt
@@ -418,7 +420,7 @@ class TestPromptDesignCommand:
 - **REQ-01**: Test requirement
 """)
 
-            result = self.runner.invoke(cli, ["prompt-design"])
+            result = self.runner.invoke(app, ["prompt-design"])
 
             assert result.exit_code == 0
             assert "design.md" in result.output
@@ -426,7 +428,7 @@ class TestPromptDesignCommand:
 
     def test_prompt_design_nonexistent_requirements(self):
         """Test prompt-design with non-existent requirements file."""
-        result = self.runner.invoke(cli, ["prompt-design", "--requirementsPath", "/nonexistent/requirements.md"])
+        result = self.runner.invoke(app, ["prompt-design", "--requirementsPath", "/nonexistent/requirements.md"])
 
         assert result.exit_code == 0
         assert "エラー" in result.output
@@ -441,7 +443,7 @@ class TestPromptDesignCommand:
 - **REQ-02**: Another requirement
 """)
 
-            result = self.runner.invoke(cli, ["prompt-design", "--requirementsPath", "custom/my_requirements.md"])
+            result = self.runner.invoke(app, ["prompt-design", "--requirementsPath", "custom/my_requirements.md"])
 
             assert result.exit_code == 0
             assert "design.md" in result.output
@@ -456,7 +458,7 @@ class TestValidateDesignCommand:
 
     def test_validate_design_help(self):
         """Test validate-design help output."""
-        result = self.runner.invoke(cli, ["validate-design", "--help"])
+        result = self.runner.invoke(app, ["validate-design", "--help"])
 
         assert result.exit_code == 0
         assert "validate-design" in result.output
@@ -465,7 +467,7 @@ class TestValidateDesignCommand:
 
     def test_validate_design_default_paths(self):
         """Test validate-design with default paths."""
-        result = self.runner.invoke(cli, ["validate-design"])
+        result = self.runner.invoke(app, ["validate-design"])
 
         assert result.exit_code == 0
         # Should show error about missing files or attempt validation
@@ -499,7 +501,7 @@ Test NFR
 Test strategy
 """)
 
-            result = self.runner.invoke(cli, ["validate-design"])
+            result = self.runner.invoke(app, ["validate-design"])
 
             assert result.exit_code == 0
             assert "検証" in result.output
@@ -512,7 +514,7 @@ Test strategy
             Path("custom/my_design.md").write_text("## アーキテクチャ\nTest [REQ-01]")
 
             result = self.runner.invoke(
-                cli,
+                app,
                 [
                     "validate-design",
                     "--designPath",
@@ -534,7 +536,7 @@ class TestPromptTasksCommand:
 
     def test_prompt_tasks_help(self):
         """Test prompt-tasks help output."""
-        result = self.runner.invoke(cli, ["prompt-tasks", "--help"])
+        result = self.runner.invoke(app, ["prompt-tasks", "--help"])
 
         assert result.exit_code == 0
         assert "prompt-tasks" in result.output
@@ -543,7 +545,7 @@ class TestPromptTasksCommand:
 
     def test_prompt_tasks_default_paths(self):
         """Test prompt-tasks with default paths."""
-        result = self.runner.invoke(cli, ["prompt-tasks"])
+        result = self.runner.invoke(app, ["prompt-tasks"])
 
         assert result.exit_code == 0
         # Should show error about missing files or attempt to generate prompt
@@ -556,7 +558,7 @@ class TestPromptTasksCommand:
             Path("specs/requirements.md").write_text("## 機能要件\n- **REQ-01**: Test")
             Path("specs/design.md").write_text("## コンポーネント設計\n- **component**: Test")
 
-            result = self.runner.invoke(cli, ["prompt-tasks"])
+            result = self.runner.invoke(app, ["prompt-tasks"])
 
             assert result.exit_code == 0
             assert "tasks.md" in result.output
@@ -572,7 +574,7 @@ class TestValidateTasksCommand:
 
     def test_validate_tasks_help(self):
         """Test validate-tasks help output."""
-        result = self.runner.invoke(cli, ["validate-tasks", "--help"])
+        result = self.runner.invoke(app, ["validate-tasks", "--help"])
 
         assert result.exit_code == 0
         assert "validate-tasks" in result.output
@@ -580,7 +582,7 @@ class TestValidateTasksCommand:
 
     def test_validate_tasks_default_path(self):
         """Test validate-tasks with default path."""
-        result = self.runner.invoke(cli, ["validate-tasks"])
+        result = self.runner.invoke(app, ["validate-tasks"])
 
         assert result.exit_code == 0
         assert "エラー" in result.output or "検証" in result.output
@@ -603,7 +605,7 @@ Dependencies
 Milestones
 """)
 
-            result = self.runner.invoke(cli, ["validate-tasks"])
+            result = self.runner.invoke(app, ["validate-tasks"])
 
             assert result.exit_code == 0
             assert "検証" in result.output
@@ -618,7 +620,7 @@ class TestPromptCodeCommand:
 
     def test_prompt_code_help(self):
         """Test prompt-code help output."""
-        result = self.runner.invoke(cli, ["prompt-code", "--help"])
+        result = self.runner.invoke(app, ["prompt-code", "--help"])
 
         assert result.exit_code == 0
         assert "prompt-code" in result.output
@@ -628,7 +630,7 @@ class TestPromptCodeCommand:
 
     def test_prompt_code_default_paths(self):
         """Test prompt-code with default paths."""
-        result = self.runner.invoke(cli, ["prompt-code"])
+        result = self.runner.invoke(app, ["prompt-code"])
 
         assert result.exit_code == 0
         assert "エラー" in result.output or "実装" in result.output
@@ -641,7 +643,7 @@ class TestPromptCodeCommand:
             Path("specs/design.md").write_text("# Design\n- Component: Test")
             Path("specs/tasks.md").write_text("# Tasks\n- **TASK-01-01**: Test")
 
-            result = self.runner.invoke(cli, ["prompt-code"])
+            result = self.runner.invoke(app, ["prompt-code"])
 
             assert result.exit_code == 0
             assert "実装" in result.output
@@ -657,7 +659,7 @@ class TestAnalyzeChangesCommand:
 
     def test_analyze_changes_help(self):
         """Test analyze-changes help output."""
-        result = self.runner.invoke(cli, ["analyze-changes", "--help"])
+        result = self.runner.invoke(app, ["analyze-changes", "--help"])
 
         assert result.exit_code == 0
         assert "analyze-changes" in result.output
@@ -666,7 +668,7 @@ class TestAnalyzeChangesCommand:
 
     def test_analyze_changes_missing_args(self):
         """Test analyze-changes without required arguments."""
-        result = self.runner.invoke(cli, ["analyze-changes"])
+        result = self.runner.invoke(app, ["analyze-changes"])
 
         assert result.exit_code != 0
         assert "Missing option" in result.output or "required" in result.output.lower()
@@ -674,7 +676,7 @@ class TestAnalyzeChangesCommand:
     def test_analyze_changes_basic_usage(self):
         """Test analyze-changes with basic usage."""
         result = self.runner.invoke(
-            cli,
+            app,
             [
                 "analyze-changes",
                 "--changedFile",
@@ -691,7 +693,7 @@ class TestAnalyzeChangesCommand:
     def test_analyze_changes_empty_description(self):
         """Test analyze-changes with empty description."""
         result = self.runner.invoke(
-            cli, ["analyze-changes", "--changedFile", "specs/requirements.md", "--changeDescription", ""]
+            app, ["analyze-changes", "--changedFile", "specs/requirements.md", "--changeDescription", ""]
         )
 
         assert result.exit_code == 0
@@ -706,7 +708,7 @@ class TestAnalyzeChangesCommand:
         """
 
         result = self.runner.invoke(
-            cli,
+            app,
             ["analyze-changes", "--changedFile", "specs/requirements.md", "--changeDescription", complex_description],
         )
 
@@ -723,7 +725,7 @@ class TestGetTraceabilityCommand:
 
     def test_get_traceability_help(self):
         """Test get-traceability help output."""
-        result = self.runner.invoke(cli, ["get-traceability", "--help"])
+        result = self.runner.invoke(app, ["get-traceability", "--help"])
 
         assert result.exit_code == 0
         assert "get-traceability" in result.output
@@ -733,7 +735,7 @@ class TestGetTraceabilityCommand:
 
     def test_get_traceability_default_paths(self):
         """Test get-traceability with default paths."""
-        result = self.runner.invoke(cli, ["get-traceability"])
+        result = self.runner.invoke(app, ["get-traceability"])
 
         assert result.exit_code == 0
         assert "トレーサビリティレポート" in result.output
@@ -746,7 +748,7 @@ class TestGetTraceabilityCommand:
             Path("specs/design.md").write_text("## アーキテクチャ\n[REQ-01]")
             Path("specs/tasks.md").write_text("## タスク一覧\n- **TASK-01-01**: Test")
 
-            result = self.runner.invoke(cli, ["get-traceability"])
+            result = self.runner.invoke(app, ["get-traceability"])
 
             assert result.exit_code == 0
             assert "トレーサビリティレポート" in result.output
@@ -759,22 +761,22 @@ class TestCLIErrorHandling:
         """Set up test environment for each test."""
         self.runner = CliRunner()
 
-    def test_cli_with_invalid_options(self):
+    def test_app_with_invalid_options(self):
         """Test CLI commands with invalid options."""
-        result = self.runner.invoke(cli, ["check-completeness", "--invalid-option", "value"])
+        result = self.runner.invoke(app, ["check-completeness", "--invalid-option", "value"])
 
         assert result.exit_code != 0
         assert "no such option" in result.output.lower() or "unknown option" in result.output.lower()
 
-    def test_cli_with_conflicting_options(self):
+    def test_app_with_conflicting_options(self):
         """Test CLI commands with conflicting options."""
         # Test with command that has multiple options
-        result = self.runner.invoke(cli, ["start-mcp-server", "--help"])
+        result = self.runner.invoke(app, ["start-mcp-server", "--help"])
 
         # Should handle gracefully (help takes precedence)
         assert "start-mcp-server" in result.output
 
-    def test_cli_commands_handle_file_errors_gracefully(self):
+    def test_app_commands_handle_file_errors_gracefully(self):
         """Test that CLI commands handle file errors gracefully."""
         commands_with_file_args = [
             ["validate-requirements", "--requirementsPath", "/invalid/path.md"],
@@ -784,25 +786,25 @@ class TestCLIErrorHandling:
         ]
 
         for command_args in commands_with_file_args:
-            result = self.runner.invoke(cli, command_args)
+            result = self.runner.invoke(app, command_args)
 
             # Commands should handle file errors gracefully and not crash
             assert result.exit_code == 0  # Should complete but show error message
             assert "エラー" in result.output
 
-    def test_cli_with_very_long_arguments(self):
+    def test_app_with_very_long_arguments(self):
         """Test CLI with very long arguments."""
         very_long_input = "A" * 100000  # 100KB of text
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", very_long_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", very_long_input])
 
         # Should handle long input without crashing
         assert result.exit_code == 0
 
-    def test_cli_with_unicode_arguments(self):
+    def test_app_with_unicode_arguments(self):
         """Test CLI with Unicode arguments."""
         unicode_input = "Unicode test: 日本語, 한국어, العربية, русский, français"
 
-        result = self.runner.invoke(cli, ["check-completeness", "--userInput", unicode_input])
+        result = self.runner.invoke(app, ["check-completeness", "--userInput", unicode_input])
 
         assert result.exit_code == 0

--- a/tests/cli/test_cli_detailed.py
+++ b/tests/cli/test_cli_detailed.py
@@ -752,37 +752,6 @@ class TestGetTraceabilityCommand:
             assert "トレーサビリティレポート" in result.output
 
 
-class TestServeCommand:
-    """Detailed serve command tests."""
-
-    def setup_method(self):
-        """Set up test environment for each test."""
-        self.runner = CliRunner()
-
-    def test_serve_help(self):
-        """Test serve help output."""
-        result = self.runner.invoke(cli, ["serve", "--help"])
-
-        assert result.exit_code == 0
-        assert "serve" in result.output
-        assert "--server" in result.output
-
-    def test_serve_without_server_flag(self):
-        """Test serve command without --server flag."""
-        result = self.runner.invoke(cli, ["serve"])
-
-        assert result.exit_code == 1
-        assert "Use --server flag" in result.output
-
-    def test_serve_with_server_flag_help_only(self):
-        """Test that serve with --server flag would start server (help test only)."""
-        # We can't actually start the server in tests, but we can verify the flag is recognized
-        result = self.runner.invoke(cli, ["serve", "--help"])
-
-        assert result.exit_code == 0
-        assert "--server" in result.output
-
-
 class TestCLIErrorHandling:
     """Test CLI error handling scenarios."""
 
@@ -799,11 +768,11 @@ class TestCLIErrorHandling:
 
     def test_cli_with_conflicting_options(self):
         """Test CLI commands with conflicting options."""
-        # Test with command that doesn't accept certain combinations
-        result = self.runner.invoke(cli, ["serve", "--server", "--help"])
+        # Test with command that has multiple options
+        result = self.runner.invoke(cli, ["start-mcp-server", "--help"])
 
         # Should handle gracefully (help takes precedence)
-        assert "serve" in result.output
+        assert "start-mcp-server" in result.output
 
     def test_cli_commands_handle_file_errors_gracefully(self):
         """Test that CLI commands handle file errors gracefully."""

--- a/uv.lock
+++ b/uv.lock
@@ -1165,6 +1165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1214,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
 ]
 
 [[package]]
@@ -1278,10 +1302,10 @@ name = "wassden"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "colorama" },
     { name = "fastmcp" },
     { name = "prompt-toolkit" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
 
@@ -1298,10 +1322,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.2.1" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "fastmcp", specifier = ">=2.11.3" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
+    { name = "typer", specifier = ">=0.12.5" },
     { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
 

--- a/wassden/cli.py
+++ b/wassden/cli.py
@@ -38,22 +38,22 @@ class TransportType(str, Enum):
 
 def print_success(message: str) -> None:
     """Print a success message in green."""
-    typer.echo(f"{Fore.GREEN}✅ {message}{Style.RESET_ALL}")
+    typer.echo(f"{Fore.GREEN}[SUCCESS] {message}{Style.RESET_ALL}")
 
 
 def print_warning(message: str) -> None:
     """Print a warning message in yellow."""
-    typer.echo(f"{Fore.YELLOW}⚠️  {message}{Style.RESET_ALL}")
+    typer.echo(f"{Fore.YELLOW}[WARNING] {message}{Style.RESET_ALL}")
 
 
 def print_error(message: str) -> None:
     """Print an error message in red."""
-    typer.echo(f"{Fore.RED}❌ {message}{Style.RESET_ALL}")
+    typer.echo(f"{Fore.RED}[ERROR] {message}{Style.RESET_ALL}")
 
 
 def print_info(message: str) -> None:
     """Print an info message in blue."""
-    typer.echo(f"{Fore.BLUE}ℹ️  {message}{Style.RESET_ALL}")
+    typer.echo(f"{Fore.BLUE}[INFO] {message}{Style.RESET_ALL}")
 
 
 async def run_handler(handler: Any, args: dict[str, Any]) -> None:

--- a/wassden/cli.py
+++ b/wassden/cli.py
@@ -19,7 +19,7 @@ from .handlers import (
     handle_validate_requirements,
     handle_validate_tasks,
 )
-from .server import main as run_server
+from .server import main as run_server_with_transport
 
 # Initialize colorama for cross-platform colored output
 init(autoreset=True)
@@ -67,15 +67,31 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option("--server", is_flag=True, help="Run as MCP server")
-def serve(server: bool) -> None:
-    """Run wassden as an MCP server."""
-    if server:
-        print_info("Starting wassden MCP server...")
-        run_server()
-    else:
-        print_error("Use --server flag to run as MCP server")
-        sys.exit(1)
+@click.option(
+    "--transport",
+    type=click.Choice(["stdio", "sse", "streamable-http"]),
+    default="stdio",
+    help="Transport type: stdio, sse, or streamable-http",
+)
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    help="HTTP host (only used for sse/streamable-http transports)",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=3001,
+    help="HTTP port (only used for sse/streamable-http transports)",
+)
+def start_mcp_server(transport: str, host: str, port: int) -> None:
+    """Start wassden MCP server with specified transport."""
+    print_info(f"Starting wassden MCP server with {transport} transport...")
+
+    if transport in ["sse", "streamable-http"]:
+        print_info(f"Listening on {host}:{port}")
+
+    run_server_with_transport(transport=transport, host=host, port=port)
 
 
 @cli.command()

--- a/wassden/server.py
+++ b/wassden/server.py
@@ -194,10 +194,25 @@ async def get_traceability(
     return str(result["content"][0]["text"])
 
 
-def main() -> None:
-    """Run the MCP server."""
-    # Run the FastMCP server
-    mcp.run()
+def main(
+    transport: str = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 3001,
+) -> None:
+    """Run the MCP server with specified transport.
+
+    Args:
+        transport: Transport type - 'stdio', 'sse', or 'streamable-http'
+        host: HTTP host (only used for sse/streamable-http transports)
+        port: HTTP port (only used for sse/streamable-http transports)
+    """
+    if transport == "stdio":
+        mcp.run()
+    elif transport in ["sse", "streamable-http"]:
+        mcp.run(transport=transport, host=host, port=port)  # type: ignore[arg-type]
+    else:
+        msg = f"Invalid transport: {transport}"
+        raise ValueError(msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Refactor CLI by migrating from Click to Typer for improved type safety and modern Python syntax.  
Rename the `serve` command to `start-mcp-server` and add transport options.  
Update server startup arguments, remove deprecated commands and related tests, and revise documentation.                                   